### PR TITLE
docs: update README; update pipeline with subsampling & threading, mapping env and run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.log
 *.DS_Store
 
+.Rhistory

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ taxonomy_sheet: "Taxonomy"
 # ref_fasta: "/path/to/custom_reference.fasta"
 trimmomatic_adapters: auto  # auto‐located in the trimmomatic env
 tskip_trimming: false # true to use existing *_trimmed FASTQs
+auto_subsample: true       # always check coverage and subsample if needed
+max_coverage: 100          # threshold (×) above which to downsample
+target_coverage: 90        # aim (×) when subsampling
 assembler: spades           # or "megahit"
 threads: 8
 mem_gb: 16

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -5,25 +5,26 @@ reads_dir: "/Users/utente/Desktop/PhD/Tuber/raw_reads"
 
 # 2. Taxonomy spreadsheet (Excel .xlsx or .csv BOLD format)
 taxonomy_file: "/Users/utente/Downloads/bold_taxonomy.xlsx"
-
-# 2.1 Taxonomy sheet of the spreadsheet
-taxonomy_sheet:   "Taxonomy"
+taxonomy_sheet:   "Taxonomy" #Taxonomy sheet of the spreadsheet
 
 # 3. Reference database (FASTA of SSU, ITS, LSU sequences) # ref_fasta is auto-downloaded if unset
 ref_fasta: "" 
 
 # 4. Path to Trimmomatic adapter file
 trimmomatic_adapters: auto # The pipeline will automatically locate the adapters in the ssuitslsu-trimmomatic Conda env
+skip_trimming:   false # if true, will *NOT* run Trimmomatic but use existing *_trimmed_1P/2P.fastq.gz
 
-# 4.1 if true, will *NOT* run Trimmomatic but use existing *_trimmed_1P/2P.fastq.gz
-skip_trimming:   false
+# 5. coverage check
+auto_subsample: true       # always check coverage and subsample if needed
+max_coverage: 100          # threshold (×) above which to downsample
+target_coverage: 90        # aim (×) when subsampling
 
-# 5. Assembler
+# 6. Assembler
 assembler: spades    # change to "spades" to run SPAdes instead
 
-# 6. Computational resources
+# 7. Computational resources
 threads: 8       # e.g. number of CPU cores to use
 mem_gb: 16       # e.g. total RAM in GB
 
-# 7. Where to put all output
+# 8. Where to put all output
 outdir: "results"

--- a/envs/mapping.yaml
+++ b/envs/mapping.yaml
@@ -6,3 +6,5 @@ channels:
 dependencies:
   - bwa-mem2
   - samtools
+  - seqtk
+  - bc


### PR DESCRIPTION
## Configuration: Subsampling & Coverage
- `auto_subsample` (bool, default: `true`): enable automatic coverage check.
- `max_coverage` (number, default: `100`): if average coverage > this, trigger down-sampling.
- `target_coverage` (number, default: `90`): desired coverage after subsampling.
The pipeline will measure mean coverage on the final BAM; if it exceeds `max_coverage`, it will subsample the FASTQs and remap to reach ~`target_coverage`.

## Mapping Reads
- Uses `bwa-mem2` + `samtools` with MAPQ ≥ 30 and only properly paired alignments (`-f 2 -F 4`).
- If mean coverage exceeds `max_coverage`, FASTQs are down-sampled with `seqtk` and remapped.
- Choose between `spades` or `megahit` via `assembler:` in `pipeline.yaml` or `--assembler` CLI flag.

## Alignment & Phylogeny
- MAFFT runs with `--thread THREADS` to parallelise the alignment.
- IQ-TREE is invoked with `-nt AUTO -ntmax THREADS -mem MEM_GB -bb 1000`